### PR TITLE
Don't quote symbol which is declared to be obsolete as a function

### DIFF
--- a/ido-ubiquitous.el
+++ b/ido-ubiquitous.el
@@ -586,7 +586,7 @@ completion for them."
       (ido-ubiquitous-fallback
        (ido-ubiquitous--explain-fallback sig)
        (apply ido-cr+-fallback-function orig-args)))))
-(define-obsolete-function-alias #'completing-read-ido #'completing-read-ido-ubiquitous
+(define-obsolete-function-alias 'completing-read-ido #'completing-read-ido-ubiquitous
   "ido-ubiquitous 3.0")
 
 ;;; Old-style default support


### PR DESCRIPTION
Quoting the obsolete function using `function` inside the form that
declares that it is an obsolete function, is considered by the byte
compiler to be the first obsolete use of that function.

Just quote the symbol using ' instead of #', otherwise the byte
compiler would issue a warning.