### PR TITLE
Make it clear advices come from ido-ubiquitous

### DIFF
--- a/ido-ubiquitous.el
+++ b/ido-ubiquitous.el
@@ -620,18 +620,18 @@ appropriate debug messages."
          (ido-ubiquitous--debug-message "Clearing `ido-ubiquitous-initial-item'.")))
        (setq ido-ubiquitous-initial-item item))))
 
-(defadvice ido-read-internal (before clear-initial-item activate)
+(defadvice ido-read-internal (before ido-ubiquitous-clear-initial-item activate)
   (ido-ubiquitous-set-initial-item nil))
 
-(defadvice ido-make-choice-list (after set-initial-item activate)
+(defadvice ido-make-choice-list (after ido-ubiquitous-set-initial-item activate)
   (ido-ubiquitous-set-initial-item
    (when (and ad-return-value (listp ad-return-value))
      (car ad-return-value))))
 
-(defadvice ido-next-match (after clear-initial-item activate)
+(defadvice ido-next-match (after ido-ubiquitous-clear-initial-item activate)
   (ido-ubiquitous-set-initial-item nil))
 
-(defadvice ido-prev-match (after clear-initial-item activate)
+(defadvice ido-prev-match (after ido-ubiquitous-clear-initial-item activate)
   (ido-ubiquitous-set-initial-item nil))
 
 ;; Clear initial item after `self-insert-command'
@@ -686,7 +686,7 @@ done in order to decide whether to swap RET and C-j. See
                 "Enabling old-style default selection")
     finally return t)))
 
-(defadvice ido-exit-minibuffer (around old-style-default-compat activate)
+(defadvice ido-exit-minibuffer (around ido-ubiquitous-old-style-default-compat activate)
   "Emulate a quirk of `completing-read'.
 
 > If the input is null, `completing-read' returns DEF, or the
@@ -705,7 +705,7 @@ advice has any effect."
      ad-do-it))
   (ido-ubiquitous-set-initial-item nil))
 
-(defadvice ido-select-text (around old-style-default-compat activate)
+(defadvice ido-select-text (around ido-ubiquitous-old-style-default-compat activate)
   "Emulate a quirk of `completing-read'.
 
 > If the input is null, `completing-read' returns DEF, or the


### PR DESCRIPTION
Hello,

When looking at functions (e.g `ido-next-match`) with `C-h f` it's not clear where the advices are defined (clear-initial-item doesn't give many clue which lib makes the advice).

This PR will make it clearer for future people like me who wonder which lib defined `clear-initial-item` :)