### PR TITLE
Fix typo for `prefix`.

### DIFF
--- a/ido-ubiquitous.el
+++ b/ido-ubiquitous.el
@@ -320,7 +320,7 @@ using overrides and disable it for everything else."
     (enable regexp "\\`\\(load\\|enable\\|disable\\|describe\\|custom-theme-visit\\)-theme\\'")
     ;; https://github.com/DarwinAwardWinner/ido-ubiquitous/issues/79
     ;; BBDB uses old-style default
-    (enable-old prefic "bbdb-")
+    (enable-old prefix "bbdb-")
     )
   "Default value of `ido-ubiquitous-command-overrides'.
 


### PR DESCRIPTION
#### What's this PR do?
Fixes a syntax error introduced in this [commit](https://github.com/DarwinAwardWinner/ido-ubiquitous/commit/7ad0114fd435995886f97d93fcc6ed879f4d6b8d).
