### PR TITLE
silence byte-compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,22 +217,6 @@ https://github.com/DarwinAwardWinner/ido-ubiquitous/issues so I can
 incorporate them into the defaults for future versions. You can also
 report any bugs you find in ido-ubiquitous.
 
-## I'm getting some weird warnings from ido-ubiquitous when Emacs starts. ##
-
-I've gotten numerous reports about nonsensical warnings produced by
-ido-ubiquitous, such as "free variable" warnings about variables that
-are most definitely properly declared, or warnings that only appear
-when ido-ubiquitous is loaded after another unrelated package. For
-many of these warnings, I've never been able to discover the cause or
-reproduce the warnings myself, and I've given up trying to figure it
-out. Please don't report any new bugs about variable warnings *unless*
-you can tell me how to consistently reproduce them starting from
-`emacs -Q`. If you are an Emacs expert who knows how to fix these
-warnings, please let me know.
-
-You can see the bug reports about weird warnings
-[here](https://github.com/DarwinAwardWinner/ido-ubiquitous/issues?utf8=%E2%9C%93&q=label%3Abizarre-unexplainable-scoping-issues+).
-
 ## What is the "bleeding-edge" branch? ##
 
 All users should just use the master branch, or better yet, install

--- a/ido-completing-read+.el
+++ b/ido-completing-read+.el
@@ -52,7 +52,13 @@ not be updated until you restart Emacs.")
 
 ;;; Debug messages
 
-(defvar ido-cr+-debug-mode)
+(define-minor-mode ido-cr+-debug-mode
+  "If non-nil, ido-cr+ will print debug info.
+
+Debug info is printed to the *Messages* buffer."
+  nil
+  :global t
+  :group 'ido-cr+)
 
 ;; Defined as a macro for efficiency (args are not evaluated unless
 ;; debug mode is on)
@@ -281,32 +287,21 @@ not allow this. In ordinary completion, RET on an incomplete
 match is equivalent to TAB, and C-j selects the first match.
 Since RET in ido already selects the first match, this advice
 sets up C-j to be equivalent to TAB in the same situation."
-  (if (and
-       ;; Only if using ico-cr+
-       ido-cr+-enable-this-call
-       ;; Only if require-match is non-nil
-       ido-require-match
-       ;; Only if current text is non-empty
-       (not (string= ido-text ""))
-       ;; Only if current text is not a complete choice
-       (not (member ido-text ido-cur-list)))
+  (if (with-no-warnings
+        (and
+         ;; Only if using ico-cr+
+         ido-cr+-enable-this-call
+         ;; Only if require-match is non-nil
+         ido-require-match
+         ;; Only if current text is non-empty
+         (not (string= ido-text ""))
+         ;; Only if current text is not a complete choice
+         (not (member ido-text ido-cur-list))))
       (progn
         (ido-cr+--debug-message
          "Overriding C-j behavior for require-match: performing completion instead of exiting.")
         (ido-complete))
     ad-do-it))
-
-;;; Debug mode
-
-;; This is defined at the end so it goes at the bottom of the
-;; customization group
-(define-minor-mode ido-cr+-debug-mode
-  "If non-nil, ido-cr+ will print debug info.
-
-Debug info is printed to the *Messages* buffer."
-  nil
-  :global t
-  :group 'ido-cr+)
 
 (provide 'ido-completing-read+)
 


### PR DESCRIPTION
```
It appears that declaring a variable (using `(defvar variable)') does
not keep the byte-compiler from complaining when that variable is used
inside a `defadvice' form.  Use `with-no-warnings' instead.  As long as
`lexical-binding' is `nil' in all the involved libraries, that should be
safe.

Move the definition of `ido-cr+-debug-mode' near the beginning of the
buffer.  There was a comment that said that it was placed near the end
of the buffer so that it appears late in the Custom interface.  But I
believe that does not actually work, and even if it did that would not
have any effect because it is the *only* option, so being the first
option is the same as being the last option.
```
This fixes, or at least mitigates #35, #61, #68, #91, #98, and #99. And yes, I (obviously) saw https://github.com/DarwinAwardWinner/ido-ubiquitous#im-getting-some-weird-warnings-from-ido-ubiquitous-when-emacs-starts but I think this is an obvious and trivial solution so I am submitting it anyway.
