### PR TITLE
Solve: reference to free variable ‘ido-cr+-minibuffer-depth’

### DIFF
--- a/ido-completing-read+.el
+++ b/ido-completing-read+.el
@@ -115,18 +115,6 @@ general, but in this case it should be, because ido always
 let-binds this variable before using it, so the initial value
 shouldn't matter.")
 
-(defvar ido-cr+-minibuffer-depth -1
-  "Minibuffer depth of the most recent ido-cr+ activation.
-
-If this equals the current minibuffer depth, then the minibuffer
-is currently being used by ido-cr+, and ido-cr+ feature will be
-active. Otherwise, something else is using the minibuffer and
-ido-cr+ features will be deactivated to avoid interfering with
-the other command.
-
-This is set to -1 by default, since `(minibuffer-depth)' should
-never return this value.")
-
 (defvar ido-cr+-assume-static-collection nil
   "If non-nil, ido-cr+ will assume that the collection is static.
 
@@ -304,6 +292,19 @@ https://github.com/DarwinAwardWinner/ido-ubiquitous/issues"
       (setq arg (cadr arg)))
     (ido-cr+--debug-message "Falling back to `%s' because %s."
                             ido-cr+-fallback-function arg)))
+
+;;;###autoload
+(defvar ido-cr+-minibuffer-depth -1
+  "Minibuffer depth of the most recent ido-cr+ activation.
+
+If this equals the current minibuffer depth, then the minibuffer
+is currently being used by ido-cr+, and ido-cr+ feature will be
+active. Otherwise, something else is using the minibuffer and
+ido-cr+ features will be deactivated to avoid interfering with
+the other command.
+
+This is set to -1 by default, since `(minibuffer-depth)' should
+never return this value.")
 
 ;;;###autoload
 (defsubst ido-cr+-active ()


### PR DESCRIPTION
Issue title: Warning (bytecomp): assignment to free variable ‘ido-cur-list’

When using `ido-completing-read+` via Melpa, an "autolaod" file is created: `~/.emacs.d/elpa/ido-completing-read+-20170707.2117/ido-completing-read+-autoloads.el`. When Emacs starts it reads this files and raises a warning: `reference to free variable ‘ido-cr+-minibuffer-depth’`. It makes sens because in the autoload file, `ido-cr+-minibuffer-depth` is used without being declared:

```elisp
(defsubst ido-cr+-active nil "\
Returns non-nil if ido-cr+ is currently using the minibuffer." (>= ido-cr+-minibuffer-depth (minibuffer-depth)))
```

In order to bring the definition in the autoload file, I added `;;;###autoload` before the declaration of `ido-cr+-minibuffer-depth` in the elisp file (`ido-completing-read+.el`).

To test this PR, I used `update-file-autoload` to export `ido-cr+-minibuffer-depth` in the autoload file. I restarted a fresh emacs (no package installed with minimal configuration to load `ido-completing-read+` via Melpa and `use-package`). I see no more warnings.

[ticket: #121]